### PR TITLE
Added HSPI Support

### DIFF
--- a/DMD32.cpp
+++ b/DMD32.cpp
@@ -47,8 +47,11 @@ DMD::DMD(byte panelsWide, byte panelsHigh)
     
     
 	
-	//initialise instance of the SPIClass attached to vspi
-	vspi = new SPIClass(VSPI);
+    //initialise instance of the SPIClass attached to vspi
+    vspi = new SPIClass(VSPI);
+	
+    //initialise instance of the SPIClass attached to HSPI
+    //vspi = new SPIClass(HSPI);
 
     // initialize the SPI port
     vspi->begin();		// initiate VSPI with the default pinsinitiat VSPI with the defualt pins

--- a/DMD32.h
+++ b/DMD32.h
@@ -49,11 +49,11 @@ LED Panel Layout in RAM
 #warning CHANGE THESE TO SEMI-ADJUSTABLE PIN DEFS!
 //ESP32 pins used for the display connection (Using VSPI)
 #define PIN_DMD_nOE		22 		// D22 active low Output Enable, setting this low lights all the LEDs in the selected rows. Can pwm it at very high frequency for brightness control.
-#define PIN_DMD_A		19		// D19
+#define PIN_DMD_A		19		// D19, 12 if HSPI
 #define PIN_DMD_B		21		// D21
-#define PIN_DMD_CLK		18		// D18_SCK  is SPI Clock if SPI is used
+#define PIN_DMD_CLK		18		// D18_SCK  is SPI Clock if SPI is used, 14 if HSPI
 #define PIN_DMD_SCLK		2		// D02
-#define PIN_DMD_R_DATA    23	// D23_MOSI is SPI Master Out if SPI is used
+#define PIN_DMD_R_DATA    23	// D23_MOSI is SPI Master Out if SPI is used, 13 if HSPI
 //Define this chip select pin that the Ethernet W5100 IC or other SPI device uses
 //if it is in use during a DMD scan request then scanDisplayBySPI() will exit without conflict! (and skip that scan)
 #define PIN_OTHER_SPI_nCS SS


### PR DESCRIPTION
Added HSPI support in ESP32.
It will use below pins instead of VSPI pins:
```
SS = GPIO 15
CLK = GPIO 14
MISO = GPIO 12
MOSI = GPIO 13
```
